### PR TITLE
Add timestamp metadata to documents

### DIFF
--- a/bitcoin.stackexchange.com/elasticsearch-scraper/main.py
+++ b/bitcoin.stackexchange.com/elasticsearch-scraper/main.py
@@ -1,5 +1,6 @@
 import requests
 import os
+from datetime import datetime
 from dotenv import load_dotenv
 from util import app_search, strip_tags, elastic_client
 from elasticsearch.helpers import bulk
@@ -66,7 +67,8 @@ def parse_posts():
                 "url": "https://bitcoin.stackexchange.com/questions/" + post.attrib.get("Id"),
                 "created_at": post.attrib.get("CreationDate"),
                 "accepted_answer_id": post.attrib.get("AcceptedAnswerId"),
-                "type": "question"
+                "type": "question",
+                "indexed_at": datetime.now().isoformat()
             }
         else: # Answer
             # Fetch question from XML
@@ -85,6 +87,7 @@ def parse_posts():
                 "created_at": post.attrib.get("CreationDate"),
                 "type": "answer",
                 "title": question.attrib.get("Title") + " (Answer)",
+                "indexed_at": datetime.now().isoformat()
             }
 
         print("Adding document: " + document["id"], document["title"])

--- a/bitcoin.stackexchange.com/main.py
+++ b/bitcoin.stackexchange.com/main.py
@@ -1,5 +1,6 @@
 import requests
 import os
+from datetime import datetime
 from dotenv import load_dotenv
 
 from util import app_search, strip_tags
@@ -66,7 +67,8 @@ def parse_posts():
                 "url": "https://bitcoin.stackexchange.com/questions/" + post.attrib.get("Id"),
                 "created_at": post.attrib.get("CreationDate"),
                 "accepted_answer_id": post.attrib.get("AcceptedAnswerId"),
-                "type": "question"
+                "type": "question",
+                "indexed_at": datetime.now().isoformat()
             }
         else: # Answer
             # Fetch question from XML
@@ -85,6 +87,7 @@ def parse_posts():
                 "created_at": post.attrib.get("CreationDate"),
                 "type": "answer",
                 "title": question.attrib.get("Title") + " (Answer)",
+                "indexed_at": datetime.now().isoformat()
             }
 
         print("Adding document: " + document["id"], document["title"])

--- a/common/elasticsearch-scraper/util.js
+++ b/common/elasticsearch-scraper/util.js
@@ -4,8 +4,9 @@ function create_batches(objects, size) {
     for (let i = 0; i < objects.length; i += size) {
         const batch = [];
         for (let j = 0; j < size; j++) {
-            if (objects[i + j]) {
-                batch.push(objects[i + j]);
+            if (objects[i + j]) { // Timestamp the object upload to strictly order it
+                const timestampedObj = {...objects[i+j], indexed_at: new Date().toISOString()}
+                batch.push(timestampedObj);
             }
         }
 

--- a/common/util.js
+++ b/common/util.js
@@ -4,8 +4,9 @@ function create_batches(objects, size) {
     for (let i = 0; i < objects.length; i += size) {
         const batch = [];
         for (let j = 0; j < size; j++) {
-            if (objects[i + j]) {
-                batch.push(objects[i + j]);
+            if (objects[i + j]) {// Timestamp the object upload to strictly order it
+                const timestampedObj = {...objects[i+j], indexed_at: new Date().toISOString()}
+                batch.push(timestampedObj);
             }
         }
 


### PR DESCRIPTION
* The `timestamp` field would be used to totally order the documents, which helps in pagination of data.