### PR TITLE
Fix: Use script tags when scraping from github

### DIFF
--- a/scrapybot/scrapybot/spiders/bips.py
+++ b/scrapybot/scrapybot/spiders/bips.py
@@ -1,4 +1,6 @@
 import re
+from bs4 import BeautifulSoup
+import json
 from datetime import datetime
 from .utils import strip_tags, strip_attributes, convert_to_iso_datetime
 import uuid
@@ -21,12 +23,14 @@ class BipsSpider(CrawlSpider):
     def parse_item(self, response):
         item = {}
 
-        body_to_be_parsed = response.xpath("//article").get()
-        bip_details = response.xpath(
-            "//*[contains(text(), 'Comments-URI')]/text()"
-        ).get()
+        soup = BeautifulSoup(response.text, "html.parser")
+        script_tags = soup.find_all("script")
+        res = script_tags[-1]
+        json_object = json.loads(res.contents[0])
+        payload = json_object["payload"]
+        body_to_be_parsed = payload["blob"]["richText"]
+        bip_details = BeautifulSoup(body_to_be_parsed, "html.parser").find("pre").text
         metadata = self.parse_details(bip_details)
-        response.xpath("//article").get()
         item["id"] = "bips-" + str(uuid.uuid4())
         item["title"] = metadata.get("Title")[0]
 
@@ -35,7 +39,7 @@ class BipsSpider(CrawlSpider):
 
         item["body_formatted"] = strip_attributes(body_to_be_parsed)
         item["body"] = strip_tags(body_to_be_parsed)
-        item["body_type"] = "mediawiki"
+        item["body_type"] = "html"
         item["authors"] = metadata.get("Author")
         item["domain"] = self.start_urls[0]
         item["url"] = response.url

--- a/scrapybot/scrapybot/spiders/btcphilosophy.py
+++ b/scrapybot/scrapybot/spiders/btcphilosophy.py
@@ -1,4 +1,6 @@
 import uuid
+from bs4 import BeautifulSoup
+import json
 from .utils import strip_tags, strip_attributes
 from datetime import datetime
 from scrapy.linkextractors import LinkExtractor
@@ -19,10 +21,20 @@ class BtcphilosophySpider(CrawlSpider):
 
     def parse_item(self, response):
         item = {}
-        article = response.xpath("//article").get()
+        soup = BeautifulSoup(response.text, "html.parser")
+        script_tags = soup.find_all("script")
+        res = script_tags[-1]
+        json_object = json.loads(res.contents[0])
+        payload = json_object["payload"]
+        article = payload["blob"]["richText"]
         item["id"] = "btcphilosophy-" + str(uuid.uuid4())
-        item["title"] = "[Bitcoin Dev Philosopy] " + response.xpath("//article/div/h2/text()").get()
 
+        item["title"] = (
+            "[Bitcoin Dev Philosopy] "
+            + BeautifulSoup(article, "html.parser")
+            .find(["h1", "h2", "h3", "h4", "h5", "h6"])
+            .text
+        )
         if not item["title"]:
             return None
 

--- a/scrapybot/scrapybot/spiders/grokkingbtc.py
+++ b/scrapybot/scrapybot/spiders/grokkingbtc.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from bs4 import BeautifulSoup
+import json
 from .utils import strip_tags, strip_attributes
 from scrapy.exceptions import DropItem
 import uuid
@@ -20,10 +22,18 @@ class GrokkingbtcSpider(CrawlSpider):
 
     def parse_item(self, response):
         item = {}
-        article = response.xpath("//article").get()
+        soup = BeautifulSoup(response.text, "html.parser")
+        script_tags = soup.find_all("script")
+        res = script_tags[-1]
+        json_object = json.loads(res.contents[0])
+        payload = json_object["payload"]
+        article = payload["blob"]["richText"]
         item["id"] = "grokkingbtc-" + str(uuid.uuid4())
-        item["title"] = "[Grokking Bitcoin] " +response.xpath("//article/div/h2/text()").get()
 
+        item["title"] = (
+            "[Grokking Bitcoin] "
+            + BeautifulSoup(article, "html.parser").find("h2").text
+        )
         if not item["title"]:
             return None
 

--- a/scrapybot/scrapybot/spiders/lndocs.py
+++ b/scrapybot/scrapybot/spiders/lndocs.py
@@ -1,4 +1,6 @@
 from .utils import strip_tags, strip_attributes
+from bs4 import BeautifulSoup
+import json
 from datetime import datetime
 import uuid
 from scrapy.linkextractors import LinkExtractor
@@ -19,9 +21,21 @@ class LndocsSpider(CrawlSpider):
 
     def parse_item(self, response):
         item = {}
-        article = response.xpath("//article").get()
+        soup = BeautifulSoup(response.text, "html.parser")
+        script_tags = soup.find_all("script")
+        res = script_tags[-1]
+        json_object = json.loads(res.contents[0])
+        payload = json_object["payload"]
+        article = payload["blob"]["richText"]
+
         item["id"] = "lndocs-" + str(uuid.uuid4())
-        item["title"] = response.xpath("//article/h1/text()").get()
+
+        item["title"] = (
+            "[Lightning-docs ] "
+            + BeautifulSoup(article, "html.parser")
+            .find(["h1", "h2", "h3", "h4", "h5", "h6"])
+            .text
+        )
 
         if not item["title"]:
             return None

--- a/scrapybot/scrapybot/spiders/programmingbtc.py
+++ b/scrapybot/scrapybot/spiders/programmingbtc.py
@@ -1,4 +1,6 @@
 import uuid
+import json
+from bs4 import BeautifulSoup
 from .utils import strip_tags, strip_attributes
 from datetime import datetime
 from scrapy.linkextractors import LinkExtractor
@@ -19,9 +21,19 @@ class ProgrammingbtcSpider(CrawlSpider):
 
     def parse_item(self, response):
         item = {}
-        article = response.xpath("//article").get()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        script_tags = soup.find_all("script")
+        res = script_tags[-1]
+        json_object = json.loads(res.contents[0])
+        payload = json_object["payload"]
+        article = payload["blob"]["richText"]
+
         item["id"] = "programmingbtc-" + str(uuid.uuid4())
-        item["title"] = "[Programming Bitcoin] " + response.xpath("//article/div/h2/text()").get()
+        item["title"] = (
+            "[Programming Bitcoin] "
+            + BeautifulSoup(article, "html.parser").find("h2").text
+        )
 
         if not item["title"]:
             return None

--- a/scrapybot/scrapybot/spiders/utils.py
+++ b/scrapybot/scrapybot/spiders/utils.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import re
 from bs4 import BeautifulSoup
 from html.parser import HTMLParser
 from datetime import datetime
@@ -31,6 +32,9 @@ def get_details(details: list):
     for item in details:
         if ": " in item:
             key, value = item.split(": ", 1)
+            if key == "Author":
+                value = re.sub(r"<[^>]+>", "", value)
+
             result_dict[key.strip()] = value.strip()
         else:
             print(f"Ignoring item: {item}")
@@ -42,6 +46,7 @@ def strip_attributes(html):
     for tag in soup.find_all():
         tag.attrs = {}
     return str(soup)
+
 
 def convert_to_iso_datetime(datetime_str):
     try:


### PR DESCRIPTION
Scraping with xpath for some tags no longer works due to a github ui update. This PR addresses that problem by using script tags instead