### PR TITLE
Refactor `parse_markdown` and extract to utils

### DIFF
--- a/bitcoinops/main.py
+++ b/bitcoinops/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import re
 import sys
 import zipfile
 from datetime import datetime
@@ -13,6 +12,7 @@ from loguru import logger
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from common.elasticsearch_utils import upsert_document
+from common.utils import parse_markdown
 
 load_dotenv()
 
@@ -58,21 +58,11 @@ async def download_repo():
         logger.error(f"Failed to unzip the file: {e}")
 
 
-def parse_markdowns(content: str):
-    sections = re.split(r'---\n', content)
-    if len(sections) < 3:
-        raise ValueError("Input text does not contain proper front matter delimiters '---'")
-    front_matter = sections[1].strip()
-    body = sections[2].strip()
-    return front_matter, body
-
-
 def parse_post(post_file: str, typeof: str):
     try:
         with open(post_file, 'r', encoding='utf-8') as file:
             content = file.read()
-        content = re.sub(r'{%.*%}', '', content, flags=re.MULTILINE)
-        front_matter, body = parse_markdowns(content)
+        front_matter, body = parse_markdown(content)
         metadata = yaml.safe_load(front_matter)
         custom_id = os.path.basename(post_file).replace('.md', '') if typeof == 'topic' else metadata['slug']
         document = {

--- a/bitcointranscripts/main.py
+++ b/bitcointranscripts/main.py
@@ -14,6 +14,7 @@ from loguru import logger
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from common.elasticsearch_utils import upsert_document
+from common.utils import parse_markdown
 
 load_dotenv()
 
@@ -77,24 +78,10 @@ def parse_posts(directory):
     return documents
 
 
-def parse_markdown(text):
-    # Split the text by the delimiter '---'
-    sections = text.split('---')
-    # If the split results in fewer than 3 parts, front matter or body is missing
-    if len(sections) < 3:
-        raise ValueError("Input text does not contain proper front matter delimiters '---'")
-    # Extract the front matter and body
-    front_matter = sections[1].strip()
-    body = sections[2].strip()
-    return front_matter, body
-
-
 def parse_post(file_path):
     with open(file_path, 'r', encoding='utf-8') as file:
         content = file.read()
 
-    # Remove content between {% %}
-    content = re.sub(r'{%.*%}', '', content, flags=re.MULTILINE)
     front_matter, body = parse_markdown(content)
     # Extract metadata from front matter using yaml
     metadata = yaml.safe_load(front_matter)

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,0 +1,18 @@
+import re
+
+def parse_markdown(text):
+    """Parses a markdown text to extract YAML front matter and the document body"""
+    # Remove content between {% %}
+    content = re.sub(r'{%.*%}', '', content, flags=re.MULTILINE)
+    # Define a regular expression pattern to match the front matter between `---\n` delimiters
+    pattern = re.compile(r'^---\s*$(.*?)^---\s*$', re.DOTALL | re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        raise ValueError("Input text does not contain proper front matter delimiters '---'")
+    
+    # Extract the front matter and the body
+    front_matter = match.group(1).strip()
+    body_start = match.end()
+    body = text[body_start:].strip()
+    
+    return front_matter, body


### PR DESCRIPTION
previous implementation was error-prune.
When "---"  was part of a string in YAML it
couldn't parse correctly.

see last runs at 
https://github.com/bitcoinsearch/scraper/actions/workflows/bitcointranscripts.yml

I have tested the new method in individual examples but not as part of the actual scrappers, so @urvishp80 please test before merging.