### PR TITLE
feat(scrapers): add Bitcoin Core PR Review Club

### DIFF
--- a/scraper/README.md
+++ b/scraper/README.md
@@ -78,7 +78,15 @@ For testing your new source configuration, see the [Development and Testing](#de
          - processor2
    ```
 
-2. **Register a scraper for the new source**:
+2. **Analyze Repository Structure** (optional):
+
+   ```bash
+   scraper github analyze NewRepo
+   ```
+
+   This helps understand what metadata fields are used across the repository before configuring scraping.
+
+3. **Register a scraper for the new source**:
 
    - If the new source can use an existing scraper, add its name to the registration of that scraper:
 
@@ -98,6 +106,17 @@ For testing your new source configuration, see the [Development and Testing](#de
      class NewRepoScraper(GithubScraper):
          async def scrape(self):
              # ... custom implementation ...
+     ```
+
+     Then export it in [`scrapers/__init__.py`](./scrapers/__init__.py):
+
+     ```python
+     from .newrepo import NewRepoScraper
+
+     __all__ = [
+         # ... existing exports ...
+         "NewRepoScraper",
+     ]
      ```
 
 #### Web Source
@@ -140,6 +159,7 @@ For testing your new source configuration, see the [Development and Testing](#de
    ```
 
    Then validate your configuration:
+
    ```bash
    scraper scrapy validate NewSite
    ```

--- a/scraper/cli.py
+++ b/scraper/cli.py
@@ -4,6 +4,7 @@ from twisted.internet.task import react
 from loguru import logger
 
 from scraper.commands.scrapy import scrapy
+from scraper.commands.github import github
 from scraper.config import settings
 from scraper.outputs import ElasticsearchOutput
 from scraper.scraper_factory import ScraperFactory
@@ -23,6 +24,7 @@ def cli():
 
 
 cli.add_command(scrapy)
+cli.add_command(github)
 
 
 def run_in_reactor(coro):

--- a/scraper/commands/github.py
+++ b/scraper/commands/github.py
@@ -1,0 +1,86 @@
+import click
+import json
+from pathlib import Path
+from loguru import logger
+
+from scraper.config import settings, get_project_root
+from scraper.registry import scraper_registry
+
+
+@click.group()
+def github():
+    """Commands for managing GitHub-based scrapers."""
+    pass
+
+
+@github.command()
+@click.argument("source")
+@click.option(
+    "--all-values",
+    is_flag=True,
+    help="Store all unique values for each field instead of just examples",
+)
+@click.option(
+    "--output-file",
+    type=click.Path(),
+    help="Output file path. Defaults to analysis_{source}.json in the project root",
+)
+def analyze(source: str, all_values: bool, output_file: str):
+    """
+    Analyze metadata fields present in markdown files of a GitHub repository.
+
+    Scans all markdown files in the repository and analyzes their metadata/front matter
+    to discover what fields are used, their frequency, types, and example values.
+
+    Example usage:
+    $ scraper github analyze bips
+    $ scraper github analyze bips --all-values
+    $ scraper github analyze bips --output-file custom_path.json
+    """
+    try:
+        # Get source configuration
+        source_config = settings.get_source_config(source)
+        if not source_config:
+            raise click.ClickException(f"Source '{source}' not found in sources.yaml")
+
+        # Verify it's a GitHub source
+        sources = settings.load_sources()
+        if not any(
+            src.name.lower() == source.lower() for src in sources.get("github", [])
+        ):
+            raise click.ClickException(
+                f"Source '{source}' is not a GitHub source. "
+                "This command is only for GitHub repositories."
+            )
+
+        # Create scraper instance
+        scraper_class = scraper_registry.get(source_config.name)
+        scraper = scraper_class(source_config, output=None, processor_manager=None)
+
+        # Run analysis if the scraper supports it
+        if not hasattr(scraper, "analyze_metadata"):
+            raise click.ClickException(
+                f"Scraper for '{source}' does not support metadata analysis."
+            )
+
+        # Run analysis
+        logger.info(f"Analyzing metadata fields in {source}...")
+        analysis = scraper.analyze_metadata(store_all_values=all_values)
+
+        # Determine output file path
+        if not output_file:
+            output_file = Path(get_project_root()) / f"analysis_{source.lower()}.json"
+
+        # Save analysis to file
+        with open(output_file, "w") as f:
+            json.dump(analysis, f, indent=2)
+
+        logger.info(f"Analysis saved to {output_file}")
+
+    except click.ClickException as e:
+        click.echo(str(e), err=True)
+        raise click.Abort()
+    except Exception as e:
+        click.echo(f"Unexpected error: {str(e)}", err=True)
+        logger.exception("Full traceback:")
+        raise click.Abort()

--- a/scraper/models/documents.py
+++ b/scraper/models/documents.py
@@ -69,6 +69,16 @@ class BitcoinTranscriptDocument(ScrapedDocument):
     transcript_source: str = Field(description="Source of the transcript")
 
 
+class PRReviewClubDocument(ScrapedDocument):
+    issue: Optional[int] = Field(
+        default_factory=None,
+        description="Bitcoin Core issue number associated with the meeting",
+    )
+    host: Optional[str] = Field(
+        default=None, description="The person hosting the meeting"
+    )
+
+
 class MetadataDocument(BaseModel):
     """
     Represents metadata about a scraping operation for a specific domain.

--- a/scraper/scrapers/__init__.py
+++ b/scraper/scrapers/__init__.py
@@ -1,7 +1,9 @@
 from .base import BaseScraper
 from .bips import BIPsScraper
+from .blips import BLIPsScraper
 from .bitcoinops import BitcoinOpsScraper
 from .bitcointranscripts import BitcoinTranscriptsScraper
+from .pr_review_club import PRReviewClubScraper
 from .github import GithubScraper
 from .scrapy.scrapy_base import ScrapyScraper
 from .scrapy.spider_base import BaseSpider
@@ -12,8 +14,10 @@ __all__ = [
     # github
     "GithubScraper",
     "BIPsScraper",
+    "BLIPsScraper",
     "BitcoinOpsScraper",
     "BitcoinTranscriptsScraper",
+    "PRReviewClubScraper",
     # scrapy
     "ScrapyScraper",
     "BaseSpider",

--- a/scraper/scrapers/pr_review_club.py
+++ b/scraper/scrapers/pr_review_club.py
@@ -1,0 +1,79 @@
+import os
+from typing import Dict, Any, Set, Type
+from urllib.parse import urljoin
+
+from scraper.models.documents import PRReviewClubDocument, ScrapedDocument
+from scraper.scrapers.github import GithubScraper
+from scraper.registry import scraper_registry
+from scraper.utils import slugify
+
+
+@scraper_registry.register("PR-Review-Club")
+class PRReviewClubScraper(GithubScraper):
+    # Predefined topics for non-Bitcoin Core meetings
+    KNOWN_TOPICS: Set[str] = {
+        "rc-testing",
+        "bitcoin-inquisition",
+        "libsecp256k1",
+        "minisketch",
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.document_class: Type[ScrapedDocument] = PRReviewClubDocument
+
+    def _extract_title_from_jekyll_filename(self, file_path: str) -> str:
+        """
+        Extract the title portion from a Jekyll filename (YYYY-MM-DD-title.md).
+        Helper method used for both URL generation and ID generation.
+        """
+        file_name = os.path.basename(file_path)
+        name_without_extension = os.path.splitext(file_name)[0]
+        # Split on first three hyphens to separate date components from title
+        parts = name_without_extension.split("-", 3)
+        return slugify(parts[3])
+
+    def get_url(self, file_path: str, metadata: Dict[str, Any]) -> str:
+        if "permalink" in metadata:
+            url_path = metadata["permalink"]
+        else:
+            url_path = self._extract_title_from_jekyll_filename(file_path)
+        return urljoin(str(self.config.domain), url_path)
+
+    def generate_id(self, file_path: str) -> str:
+        title = self._extract_title_from_jekyll_filename(file_path)
+        return f"{self.config.name.lower()}-{title}"
+
+    def customize_document(
+        self, document_data: Dict[str, Any], file_path: str, metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Customize document data based on metadata and file information.
+        For Bitcoin Core PRs, uses PR number and metadata.
+        For other content, identifies topics from filename.
+        """
+        document_data["issue"] = metadata.get("pr", None)
+        document_data["host"] = metadata.get("host", [])
+        document_data["tags"] = metadata.get("components", []) or []
+
+        # If no PR number exists, this is not a Bitcoin Core PR review
+        if not document_data["issue"]:
+            # Extract title from filename
+            title = self._extract_title_from_jekyll_filename(file_path)
+
+            # Find matching topics
+            matching_topics = [topic for topic in self.KNOWN_TOPICS if topic in title]
+
+            if not matching_topics:
+                raise ValueError(
+                    f"File '{file_path}' is not related to Bitcoin Core PR"
+                    f"doesn't match any known topics"
+                )
+
+            # Add matched topics to tags
+            if isinstance(document_data["tags"], list):
+                document_data["tags"].extend(list(matching_topics))
+            else:
+                document_data["tags"] = list(matching_topics)
+
+        return document_data

--- a/scraper/sources.yaml
+++ b/scraper/sources.yaml
@@ -21,6 +21,11 @@ github:
       - summarization
       - topic_extractor
       - vector_embeddings
+  - name: PR-Review-Club
+    domain: https://bitcoincore.reviews/
+    url: https://github.com/bitcoin-core-review-club/website.git
+    directories: 
+      _posts: post
 web:
   - name: BitcoinTalk
     domain: https://bitcointalk.org


### PR DESCRIPTION
This PR adds a scraper for the Bitcoin Core PR Review Club meetings.
Includes special handling for meetings not directly related with a PR, like rc-testing and bitcoin-inquisition.

Additionally, it adds the `scraper github analyze <>` command to analyze metadata fields in GitHub repositories' markdown files. The analyzer scans all markdown files, tracks field usage frequency, detects value types, and can store either examples or all unique values per field. Results are saved to a JSON file for easy inspection, providing insights into the metadata structure and patterns across repository documents.

