### PR TITLE
feat(scrapers): Add GitHub metadata scraper for issues and pull requests

### DIFF
--- a/scraper/README.md
+++ b/scraper/README.md
@@ -29,6 +29,12 @@ A flexible multi-source scraper application designed to gather information from 
 - List available sources: `poetry run scraper list-sources`
 - Show configuration: `poetry run scraper show-config`
 
+### Elasticsearch Management
+
+- Initialize index with custom mapping: `poetry run scraper elastic init-index <my_index> path/to/mapping.json`
+- Show index mapping: `poetry run scraper elastic show-mapping <my_index>`
+- Clean up test documents: `poetry run scraper elastic cleanup-index <my_index> --test-docs-only`
+
 ## Sources Configuration
 
 The scraper uses a registry-based architecture to manage scrapers, processors, and outputs. This design allows for flexible configuration and easy extensibility.
@@ -303,7 +309,7 @@ When testing Elasticsearch integration:
 
 3. Clean up test documents when done:
    ```bash
-   scraper cleanup-test-documents
+   scraper elastic cleanup-index <my_index> --test-docs-only
    ```
 
 This workflow allows you to verify correct document indexing by testing the full pipeline while also ensuring that the test documents are removed after the tests are complete.

--- a/scraper/commands/elastic.py
+++ b/scraper/commands/elastic.py
@@ -1,0 +1,146 @@
+import click
+import json
+from pathlib import Path
+from twisted.internet.task import react
+from twisted.internet import defer
+
+from scraper.outputs import ElasticsearchOutput
+
+
+def run_in_reactor(coro):
+    """Bridge between coroutines and Twisted's deferred system."""
+    return defer.ensureDeferred(coro)
+
+
+@click.group()
+def elastic():
+    """Commands for managing Elasticsearch indices."""
+    pass
+
+
+@elastic.command()
+@click.argument("index_name")
+@click.argument("mapping_file", type=click.Path(exists=True, path_type=Path))
+@click.option("--force", is_flag=True, help="Delete index if it exists")
+def init_index(index_name: str, mapping_file: Path, force: bool):
+    """
+    Initialize an Elasticsearch index with a custom mapping.
+
+    Example usage:
+    $ scraper elastic init-index my_index mappings/github_metadata.json
+    $ scraper elastic init-index my_index mappings/github_metadata.json --force
+    """
+    try:
+        from twisted.internet import asyncioreactor
+
+        asyncioreactor.install()
+    except Exception:
+        pass
+
+    def run_init(reactor):
+        async def initialize():
+            output = ElasticsearchOutput(index_name=index_name)
+
+            try:
+                with open(mapping_file) as f:
+                    mapping = json.load(f)
+            except json.JSONDecodeError:
+                raise click.ClickException(
+                    f"Invalid JSON in mapping file: {mapping_file}"
+                )
+            except Exception as e:
+                raise click.ClickException(f"Error reading mapping file: {e}")
+
+            async with output:
+                if force and output.es.indices.exists(index=index_name):
+                    output.es.indices.delete(index=index_name)
+                    click.echo(f"Deleted existing index: {index_name}")
+
+                await output.create_index_with_mapping(index_name, mapping)
+                click.echo(
+                    f"Successfully created index {index_name} with mapping from {mapping_file}"
+                )
+
+        return run_in_reactor(initialize())
+
+    react(run_init)
+
+
+@elastic.command()
+@click.argument("index_name")
+@click.option(
+    "--test-docs-only",
+    is_flag=True,
+    help="Remove only documents marked as test_document=True",
+)
+def cleanup_index(index_name: str, test_docs_only: bool):
+    """
+    Remove documents from the specified Elasticsearch index.
+
+    By default removes all documents. Use --test-docs-only to remove only test documents.
+
+    Example usage:
+    $ scraper elastic cleanup-index my_index
+    $ scraper elastic cleanup-index my_index --test-docs-only
+    """
+    try:
+        from twisted.internet import asyncioreactor
+
+        asyncioreactor.install()
+    except Exception:
+        pass
+
+    def run_cleanup(reactor):
+        output = ElasticsearchOutput(index_name=index_name)
+
+        async def cleanup():
+            async with output:
+                if not output.es.indices.exists(index=index_name):
+                    click.echo(f"Index {index_name} does not exist")
+                    return
+
+                if test_docs_only:
+                    await output.cleanup_test_documents(index_name)
+                    click.echo(f"Cleaned up test documents from index {index_name}")
+                else:
+                    output.es.delete_by_query(
+                        index=index_name, body={"query": {"match_all": {}}}
+                    )
+                    click.echo(f"Removed all documents from index {index_name}")
+
+        return run_in_reactor(cleanup())
+
+    react(run_cleanup)
+
+
+@elastic.command()
+@click.argument("index_name")
+def show_mapping(index_name: str):
+    """
+    Show the current mapping for an index.
+
+    Example usage:
+    $ scraper elastic show-mapping my_index
+    """
+    try:
+        from twisted.internet import asyncioreactor
+
+        asyncioreactor.install()
+    except Exception:
+        pass
+
+    def run_show(reactor):
+        async def show():
+            output = ElasticsearchOutput(index_name=index_name)
+
+            async with output:
+                if not output.es.indices.exists(index=index_name):
+                    click.echo(f"Index {index_name} does not exist")
+                    return
+
+                mapping = output.es.indices.get_mapping(index=index_name)
+                click.echo(json.dumps(mapping.body, indent=2))
+
+        return run_in_reactor(show())
+
+    react(run_show)

--- a/scraper/config.py
+++ b/scraper/config.py
@@ -13,13 +13,8 @@ def get_project_root():
     Find the project root by searching for a specific file.
 
     This function traverses up the directory tree from the current file's location
-    until it finds a directory containing 'pyproject.toml', which is assumed to be
+    until it finds a directory containing 'cli.py', which is assumed to be
     the project root.
-
-    Assumptions:
-    1. The project uses Poetry and thus has a pyproject.toml file in its root.
-    2. The function has permission to read the directory structure.
-    3. The project root is not beyond the file system root (/).
 
     Returns:
         str: The absolute path to the project root directory.

--- a/scraper/mappings/github_metadata.json
+++ b/scraper/mappings/github_metadata.json
@@ -1,0 +1,124 @@
+{
+  "mappings": {
+    "properties": {
+      "id": { "type": "keyword" },
+      "title": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "body": { "type": "text" },
+      "body_formatted": { "enabled": false },
+      "body_type": { "type": "keyword" },
+      "summary": { "type": "text" },
+      "domain": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "indexed_at": { "type": "date" },
+      "created_at": { "type": "date" },
+      "url": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "thread_url": { "type": "keyword" },
+      "type": { "type": "keyword" },
+      "language": { "type": "keyword" },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "authors": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "test_document": { "type": "boolean" },
+      "number": { "type": "keyword" },
+      "updated_at": { "type": "date" },
+      "closed_at": { "type": "date" },
+      "merged_at": { "type": "date" },
+      "state": { "type": "keyword" },
+      "labels": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "head_sha": { "type": "keyword" },
+      "reviews": {
+        "type": "nested",
+        "properties": {
+          "id": { "type": "long" },
+          "author": { "type": "keyword" },
+          "commit_id": { "type": "keyword" },
+          "submitted_at": { "type": "date" },
+          "body": { "type": "text" }
+        }
+      },
+      "review_threads": {
+        "type": "nested",
+        "properties": {
+          "pull_request_review_id": { "type": "long" },
+          "path": { "type": "keyword" },
+          "diff_hunk": { "type": "text" },
+          "commit_id": { "type": "keyword" },
+          "original_commit_id": { "type": "keyword" },
+          "position": { "type": "integer" },
+          "original_position": { "type": "integer" },
+          "line": { "type": "integer" },
+          "original_line": { "type": "integer" },
+          "start_line": { "type": "integer" },
+          "original_start_line": { "type": "integer" },
+          "comments": {
+            "type": "nested",
+            "properties": {
+              "id": { "type": "long" },
+              "author": { "type": "keyword" },
+              "created_at": { "type": "date" },
+              "updated_at": { "type": "date" },
+              "body": { "type": "text" },
+              "pull_request_review_id": { "type": "long" }
+            }
+          }
+        }
+      },
+      "comments": {
+        "type": "nested",
+        "properties": {
+          "id": { "type": "long" },
+          "author": { "type": "keyword" },
+          "created_at": { "type": "date" },
+          "updated_at": { "type": "date" },
+          "body": { "type": "text" }
+        }
+      }
+    }
+  }
+}

--- a/scraper/models/documents.py
+++ b/scraper/models/documents.py
@@ -70,9 +70,9 @@ class BitcoinTranscriptDocument(ScrapedDocument):
 
 
 class PRReviewClubDocument(ScrapedDocument):
-    issue: Optional[int] = Field(
+    number: Optional[int] = Field(
         default_factory=None,
-        description="Bitcoin Core issue number associated with the meeting",
+        description="Bitcoin Core PR number associated with the meeting",
     )
     host: Optional[str] = Field(
         default=None, description="The person hosting the meeting"

--- a/scraper/models/github_metadata.py
+++ b/scraper/models/github_metadata.py
@@ -1,0 +1,125 @@
+from typing import List, Optional, Literal
+from pydantic import BaseModel, Field
+
+from scraper.models.documents import ScrapedDocument
+
+
+class Review(BaseModel):
+    """Represents a formal code review on a pull request"""
+
+    id: int = Field(description="Unique identifier for the review")
+    author: str = Field(description="Username of the reviewer")
+    commit_id: str = Field(
+        description="The SHA of the commit to which the review applies"
+    )
+    submitted_at: str = Field(description="When the review was submitted")
+    body: str = Field(description="The review's comment text")
+
+
+class ThreadComment(BaseModel):
+    """Represents a comment in a review thread"""
+
+    id: int = Field(description="Unique identifier for the comment")
+    author: str = Field(description="Username of the comment author")
+    created_at: str = Field(description="When the comment was created")
+    updated_at: str = Field(description="When the comment was last updated")
+    body: str = Field(description="The text of the comment")
+    pull_request_review_id: Optional[int] = Field(
+        None, description="ID of the associated review"
+    )
+
+
+class ReviewThread(BaseModel):
+    """Represents a discussion thread on a specific code section"""
+
+    pull_request_review_id: Optional[int] = Field(
+        None, description="The ID of the pull request review that initiated this thread"
+    )
+    path: str = Field(
+        description="The relative path of the file to which the thread applies"
+    )
+    diff_hunk: str = Field(
+        description="The diff of the line that the review thread refers to"
+    )
+    commit_id: str = Field(
+        description="The SHA of the commit to which the review thread applies"
+    )
+    original_commit_id: str = Field(
+        description="The SHA of the original commit to which the review thread applies"
+    )
+    position: Optional[int] = Field(
+        None,
+        description="The line index in the diff to which the comment applies. This field is closing down; use `line` instead",
+    )
+    original_position: Optional[int] = Field(
+        None,
+        description="The index of the original line in the diff to which the comment applies. This field is closing down; use `original_line` instead.",
+    )
+    line: Optional[int] = Field(
+        None,
+        description="The line of the blob to which the review thread applies. The last line of the range for a multi-line comment",
+    )
+    original_line: Optional[int] = Field(
+        None,
+        description="The original line of the blob to which the review thread applies. The last line of the range for a multi-line comment",
+    )
+    start_line: Optional[int] = Field(
+        None, description="The first line of the range for a multi-line comment"
+    )
+    original_start_line: Optional[int] = Field(
+        None,
+        description="The original first line of the range for a multi-line comment",
+    )
+    comments: List[ThreadComment] = Field(
+        default_factory=list, description="Comments in this thread"
+    )
+
+
+class Comment(BaseModel):
+    """Represents a general comment on the issue/PR"""
+
+    id: int = Field(description="Unique identifier for the comment")
+    author: str = Field(description="Username of the comment author")
+    created_at: str = Field(description="When the comment was created")
+    updated_at: str = Field(description="When the comment was last updated")
+    body: str = Field(description="The text of the comment")
+
+
+class GitHubDocument(ScrapedDocument):
+    """Represents a GitHub Issue or Pull Request document with all its associated data"""
+
+    type: Literal["issue", "pull"] = Field(
+        description="Document type: 'issue' or 'pull'"
+    )
+    number: str = Field(description="Issue or PR number")
+    body: str = Field(description="Issue/PR description")
+    body_type: Literal["markdown"] = Field(
+        "markdown", description="Content format type"
+    )
+    created_at: str = Field(description="When the issue/PR was created")
+    updated_at: str = Field(description="When the issue/PR was last updated")
+    closed_at: Optional[str] = Field(description="When the issue/PR was closed")
+    merged_at: Optional[str] = Field(description="When the PR was merged")
+    state: Literal["open", "merged", "closed", "draft"] = Field(
+        description="Current state"
+    )
+    labels: List[str] = Field(default_factory=list, description="Issue/PR labels")
+
+    # Optional PR-specific fields
+    head_sha: Optional[str] = Field(
+        default=None, description="SHA of the PR head commit"
+    )
+    draft: Optional[bool] = Field(
+        default=False, description="Whether the PR is a draft"
+    )
+    reviews: Optional[List[Review]] = Field(
+        default=None, description="Formal code reviews (PR only)"
+    )
+    review_threads: Optional[List[ReviewThread]] = Field(
+        default=None, description="Code review discussion threads (PR only)"
+    )
+
+    # Common fields
+    comments: List[Comment] = Field(
+        default_factory=list, description="General comments"
+    )

--- a/scraper/outputs/elasticsearch_output.py
+++ b/scraper/outputs/elasticsearch_output.py
@@ -112,3 +112,19 @@ class ElasticsearchOutput(AbstractOutput):
             logger.error(f"Error cleaning up test documents: {e}")
             logger.exception("Full traceback:")
             raise
+
+    async def create_index_with_mapping(self, index_name: str, mapping: dict):
+        """
+        Create an index with a specific mapping.
+        If the index exists, raise an error.
+        """
+        try:
+            if self.es.indices.exists(index=index_name):
+                raise ValueError(f"Index {index_name} already exists")
+
+            self.es.indices.create(index=index_name, body=mapping)
+            logger.info(f"Created index {index_name} with custom mapping")
+
+        except Exception as e:
+            logger.error(f"Error creating index {index_name}: {e}")
+            raise

--- a/scraper/scrapers/__init__.py
+++ b/scraper/scrapers/__init__.py
@@ -5,6 +5,7 @@ from .bitcoinops import BitcoinOpsScraper
 from .bitcointranscripts import BitcoinTranscriptsScraper
 from .pr_review_club import PRReviewClubScraper
 from .github import GithubScraper
+from .github_metadata import GitHubMetadataScraper
 from .scrapy.scrapy_base import ScrapyScraper
 from .scrapy.spider_base import BaseSpider
 from .scrapy.bitcointalk import BitcoinTalkScraper
@@ -19,6 +20,8 @@ __all__ = [
     "BitcoinOpsScraper",
     "BitcoinTranscriptsScraper",
     "PRReviewClubScraper",
+    ## github metadata
+    "GitHubMetadataScraper",
     # scrapy
     "ScrapyScraper",
     "BaseSpider",

--- a/scraper/scrapers/github_metadata.py
+++ b/scraper/scrapers/github_metadata.py
@@ -1,0 +1,237 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from loguru import logger
+
+from scraper.registry import scraper_registry
+from scraper.scrapers.github import GithubScraper
+from scraper.models.github_metadata import (
+    GitHubDocument,
+    Review,
+    ReviewThread,
+    ThreadComment,
+    Comment,
+)
+
+
+@scraper_registry.register(
+    "github-metadata-bitcoin-bips",
+    "github-metadata-bitcoin-bitcoin",
+    "github-metadata-bitcoin-core-secp256k1",
+    "github-metadata-bitcoin-core-gui",
+)
+class GitHubMetadataScraper(GithubScraper):
+    """
+    Specialized scraper for GitHub Issues and Pull Requests data stored in JSON files.
+    Transforms the raw GitHub API backup data into our normalized document format.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.document_class = GitHubDocument
+
+    def is_valid_file_type(self, file_path: str) -> bool:
+        """Override to check for JSON files instead of markdown."""
+        return file_path.endswith(".json")
+
+    def parse_file(self, repo, file_path: str) -> Optional[GitHubDocument]:
+        """
+        Parse a JSON file containing GitHub issue/PR data.
+
+        Args:
+            repo: The Git repository object
+            file_path: Path to the JSON file within the repository
+
+        Returns:
+            GitHubDocument: The parsed document or None if parsing fails
+        """
+        try:
+            # Read the JSON file
+            with open(Path(repo.working_dir) / file_path, "r", encoding="utf-8") as f:
+                json_content = json.load(f)
+
+            # Process the JSON content
+            document_data = self.map_json_to_document(json_content, file_path)
+
+            # Add common fields
+            document_data.update(
+                {
+                    "id": self.generate_id(file_path),
+                    "domain": str(self.config.domain),
+                    "url": self.get_url(file_path, document_data),
+                }
+            )
+
+            return self.document_class(**document_data)
+
+        except Exception as e:
+            logger.error(f"Error parsing JSON file {file_path}: {e}")
+            logger.exception("Full traceback:")
+            return None
+
+    def map_json_to_document(
+        self, json_content: Dict[str, Any], file_path: str
+    ) -> Dict[str, Any]:
+        """Transform GitHub JSON data into our document format"""
+        try:
+            content_type = json_content["type"]
+            if content_type not in ["issue", "pull"]:
+                raise ValueError(f"Unknown content type: {content_type}")
+
+            data = json_content[content_type]
+
+            # Map base fields common to both issues and PRs
+            document_data = {
+                "type": content_type,
+                "number": str(data["number"]),
+                "title": data["title"],
+                "authors": [data["user"]["login"]],
+                "body": data.get("body", ""),
+                "body_type": "markdown",
+                "created_at": data["created_at"],
+                "updated_at": data["updated_at"],
+                "closed_at": data.get("closed_at"),
+                "merged_at": data.get("merged_at"),
+                "state": self._determine_state(data, content_type),
+                "labels": [label["name"] for label in data["labels"]],
+                "comments": self._extract_comments(json_content),
+            }
+
+            # Add PR-specific fields if this is a pull request
+            if content_type == "pull":
+                document_data.update(
+                    {
+                        "head_sha": data["head"]["sha"],
+                        "draft": data.get("draft", False),
+                        "reviews": self._extract_reviews(json_content),
+                        "review_threads": self._extract_review_threads(json_content),
+                    }
+                )
+
+            return document_data
+
+        except Exception as e:
+            logger.error(f"Error mapping data from {file_path}: {e}")
+            raise
+
+    def _determine_state(self, data: Dict[str, Any], content_type: str) -> str:
+        """Determine the state based on content type and data"""
+        if content_type == "pull":
+            if data.get("merged_at"):
+                return "merged"
+
+        return data["state"]  # "open" or "closed"
+
+    def _extract_reviews(self, json_content: Dict[str, Any]) -> List[Review]:
+        """Extract formal reviews from events"""
+        reviews = []
+        for event in json_content["events"]:
+            if event.get("event") == "reviewed":
+                try:
+                    reviews.append(
+                        Review(
+                            id=int(event["id"]),
+                            author=event["user"]["login"],
+                            commit_id=event["commit_id"],
+                            submitted_at=event["submitted_at"],
+                            body=event.get("body", ""),
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(f"Skipping invalid review: {e}")
+        return reviews
+
+    def _extract_review_threads(
+        self, json_content: Dict[str, Any]
+    ) -> List[ReviewThread]:
+        """Extract review threads from comments"""
+        # Group comments by their thread attributes
+        threads: Dict[str, List[Dict[str, Any]]] = {}
+
+        # Comments array contains only review thread comments
+        for comment in json_content["comments"]:
+            thread_key = f"{comment['path']}:{comment.get('position')}:{comment.get('original_position')}"
+
+            if thread_key not in threads:
+                threads[thread_key] = []
+            threads[thread_key].append(comment)
+
+        # Convert grouped comments to ReviewThread objects
+        review_threads = []
+        for thread_comments in threads.values():
+            if not thread_comments:
+                continue
+
+            # Use the first comment for thread-level attributes
+            first_comment = thread_comments[0]
+            try:
+                thread = ReviewThread(
+                    pull_request_review_id=first_comment.get("pull_request_review_id"),
+                    path=first_comment["path"],
+                    diff_hunk=first_comment.get("diff_hunk", ""),
+                    commit_id=first_comment["commit_id"],
+                    original_commit_id=first_comment["original_commit_id"],
+                    position=first_comment.get("position"),
+                    original_position=first_comment.get("original_position"),
+                    line=first_comment.get("line"),
+                    original_line=first_comment.get("original_line"),
+                    start_line=first_comment.get("start_line"),
+                    original_start_line=first_comment.get("original_start_line"),
+                    comments=[
+                        self._convert_to_thread_comment(c) for c in thread_comments
+                    ],
+                )
+                review_threads.append(thread)
+            except Exception as e:
+                logger.warning(f"Skipping invalid review thread: {e}")
+
+        return review_threads
+
+    def _convert_to_thread_comment(self, comment: Dict[str, Any]) -> ThreadComment:
+        """Convert a raw comment dict to a ThreadComment object"""
+        return ThreadComment(
+            id=int(comment["id"]),
+            author=comment["user"]["login"],
+            created_at=comment["created_at"],
+            updated_at=comment["updated_at"],
+            body=comment["body"],
+            pull_request_review_id=comment.get("pull_request_review_id"),
+        )
+
+    def _extract_comments(self, json_content: Dict[str, Any]) -> List[Comment]:
+        """Extract general comments from events array where event type is 'commented'"""
+        comments = []
+        for event in json_content["events"]:
+            if event.get("event") != "commented":
+                continue
+
+            try:
+                comments.append(
+                    Comment(
+                        id=int(event["id"]),
+                        author=event["actor"]["login"],
+                        created_at=event["created_at"],
+                        updated_at=event["updated_at"],
+                        body=event["body"],
+                    )
+                )
+            except Exception as e:
+                logger.warning(f"Skipping invalid comment: {e}")
+
+        return comments
+
+    def get_url(self, file_path: str, metadata: Dict[str, Any]) -> str:
+        """Generate the GitHub web URL for the issue/PR"""
+        base_url = self.config.domain
+        item_type = metadata.get("type")
+        number = metadata.get("number")
+
+        if not all([base_url, item_type, number]):
+            raise ValueError("Missing required fields: domain, type, or number")
+
+        if item_type == "issue":
+            return f"{base_url}/issues/{number}"
+        elif item_type == "pull":
+            return f"{base_url}/pull/{number}"
+        else:
+            raise ValueError(f"Invalid type: {item_type}. Must be 'issue' or 'pull'")

--- a/scraper/scrapers/pr_review_club.py
+++ b/scraper/scrapers/pr_review_club.py
@@ -52,12 +52,12 @@ class PRReviewClubScraper(GithubScraper):
         For Bitcoin Core PRs, uses PR number and metadata.
         For other content, identifies topics from filename.
         """
-        document_data["issue"] = metadata.get("pr", None)
+        document_data["number"] = metadata.get("pr", None)
         document_data["host"] = metadata.get("host", [])
         document_data["tags"] = metadata.get("components", []) or []
 
         # If no PR number exists, this is not a Bitcoin Core PR review
-        if not document_data["issue"]:
+        if not document_data["number"]:
             # Extract title from filename
             title = self._extract_title_from_jekyll_filename(file_path)
 

--- a/scraper/sources.yaml
+++ b/scraper/sources.yaml
@@ -26,6 +26,18 @@ github:
     url: https://github.com/bitcoin-core-review-club/website.git
     directories: 
       _posts: post
+  - name: github-metadata-bitcoin-bips
+    domain: https://github.com/bitcoin/bips
+    url: https://github.com/bitcoin-data/github-metadata-backup-bitcoin-bips.git
+  - name: github-metadata-bitcoin-bitcoin
+    domain: https://github.com/bitcoin/bitcoin
+    url: https://github.com/bitcoin-data/github-metadata-backup-bitcoin-bitcoin.git
+  - name: github-metadata-bitcoin-core-secp256k1
+    domain: https://github.com/bitcoin-core/secp256k1
+    url: https://github.com/bitcoin-data/github-metadata-backup-bitcoin-core-secp256k1.git
+  - name: github-metadata-bitcoin-core-gui
+    domain: https://github.com/bitcoin-core/gui
+    url: https://github.com/bitcoin-data/github-metadata-backup-bitcoin-core-gui.git
 web:
   - name: BitcoinTalk
     domain: https://bitcointalk.org


### PR DESCRIPTION
This PR adds support for scraping all the existing github metadata backups from [bitcoin-data](https://github.com/bitcoin-data/) which updates every hour for the following repositories: `bitcoin/bips`, `bitcoin/bitcoin`, `bitcoin-core/secp256k1`, `bitcoin-core/gui`, thus fixes #92 

Additionally, this PR introduces a separate 'elastic' command group that handles index initialization with custom mappings, cleanup operations, and mapping inspection. We need index initialization with custom mapping in order to model the relationships between documents in the current github metadata schema [using nesting](https://opster.com/guides/elasticsearch/data-architecture/how-to-model-relationships-between-documents-in-elasticsearch-using-nesting).

An experimental addition to the Bitcoin Search API is currently in progress in order to better showcase and validate this scraper.

## The Schema

The schema is designed to store three main types of content:
1. Issue/PR metadata
2. Reviews (for PRs)
3. Comments (both general comments and review-related discussions)

and can be found at `scraper/models/github_metadata.py`

This schema allows for efficient querying of:
- Issues and PRs by type, state, labels, or authors
- All comments on a specific file or line
- Complete review threads with their full discussion history
- Reviews by specific users or on specific commits
- General comments
- ...

The nested structure maintains the relationships between reviews, threads, and comments while allowing for efficient querying and aggregation at each level.

**Example document**

```json
{
  "id": "github-metadata-bitcoin-core-12345",
  "title": "Add new validation rules for taproot transactions",
  "body": "This PR implements additional validation rules for taproot transactions as specified in BIP 341. It adds checks for:\n\n- Script path spending conditions\n- Leaf version requirements\n- Signature verification rules\n\nThe changes have been tested extensively with the test vectors from BIP 341.",
  "body_type": "markdown",
  "domain": "https://github.com/bitcoin/bitcoin",
  "indexed_at": "2024-12-10T12:00:00.000Z",
  "created_at": "2024-03-15T14:30:00Z",
  "url": "https://github.com/bitcoin/bitcoin/pull/12345",
  "type": "pull",
  "authors": ["alice-developer"],
  "number": "12345",
  "updated_at": "2024-03-20T09:15:00Z",
  "closed_at": "2024-03-25T16:45:00Z",
  "merged_at": "2024-03-25T16:45:00Z",
  "state": "merged",
  "labels": ["consensus", "needs testing", "taproot"],
  "head_sha": "abc123def456789ghijklmnop0123456789qrstuv",
  "draft": false,
  "reviews": [
    {
      "id": 987654321,
      "author": "bob-reviewer",
      "commit_id": "abc123def456789ghijklmnop0123456789qrstuv",
      "submitted_at": "2024-03-18T11:20:00Z",
      "body": "The implementation looks correct and follows the BIP specification. Tested with the provided test vectors."
    }
  ],
  "review_threads": [
    {
      "pull_request_review_id": 987654321,
      "path": "src/consensus/validation.cpp",
      "diff_hunk": "@@ -150,6 +150,15 @@ bool CheckTaprootSignature(...)",
      "commit_id": "abc123def456789ghijklmnop0123456789qrstuv",
      "original_commit_id": "abc123def456789ghijklmnop0123456789qrstuv",
      "position": 8,
      "original_position": 8,
      "line": 158,
      "original_line": 158,
      "comments": [
        {
          "id": 11111111,
          "author": "bob-reviewer",
          "created_at": "2024-03-18T11:25:00Z",
          "updated_at": "2024-03-18T11:25:00Z",
          "body": "Consider adding a comment explaining the merkle path verification logic here.",
          "pull_request_review_id": 987654321
        }
      ]
    }
  ],
  "comments": [
    {
      "id": 22222222,
      "author": "charlie-commenter",
      "created_at": "2024-03-16T10:00:00Z",
      "updated_at": "2024-03-16T10:00:00Z",
      "body": "Have you considered adding test cases for edge cases with empty script paths?"
    }
  ]
}
```